### PR TITLE
Pass through helper text if it is provided

### DIFF
--- a/src/TextField.js
+++ b/src/TextField.js
@@ -12,7 +12,7 @@ export default createComponent(
       ...props,
       ...field,
       error: touched[name] && !!errors[name],
-      helperText: errors[name],
+      helperText: errors[name] ? errors[name] : props.helperText,
     };
   }
 );


### PR DESCRIPTION
If there is an error, show that as helperText. Otherwise, pass
through supplied helper text.