### PR TITLE
Show nested field error message

### DIFF
--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -18,14 +18,14 @@ export const fieldToTextField = ({
   const { name } = field;
   const { touched, errors, isSubmitting } = form;
 
+  const fieldError = getIn(errors, name);
+  const showError = getIn(touched, name) && fieldError;
+
   return {
     ...props,
     ...field,
-    error: getIn(touched, name) && !!getIn(errors, name),
-    helperText:
-      getIn(touched, name) && getIn(errors, name)
-        ? getIn(errors, name)
-        : props.helperText,
+    error: showError,
+    helperText: showError ? fieldError : props.helperText,
     disabled: isSubmitting || disabled,
   };
 };

--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -22,7 +22,10 @@ export const fieldToTextField = ({
     ...props,
     ...field,
     error: getIn(touched, name) && !!getIn(errors, name),
-    helperText: touched[name] && errors[name] ? errors[name] : props.helperText,
+    helperText:
+      getIn(touched, name) && getIn(errors, name)
+        ? getIn(errors, name)
+        : props.helperText,
     disabled: isSubmitting || disabled,
   };
 };


### PR DESCRIPTION
**Current behavior:**
If the field name is "user.email" (or something else, but it must be nested) type some text that will fail the validation.
The field color would change to red
No helper text

**Expected:**
Helper text should be present as well