### PR TITLE
Allow disabled=true on TextField, even when submitting

### DIFF
--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -13,7 +13,7 @@ export const fieldToTextField = ({
   field,
   form,
   variant,
-  disabled = false,
+  disabled = undefined,
   ...props
 }: TextFieldProps): MuiTextFieldProps => {
   const { name } = field;
@@ -30,7 +30,7 @@ export const fieldToTextField = ({
     variant: variant as any,
     error: showError,
     helperText: showError ? fieldError : props.helperText,
-    disabled: isSubmitting || disabled,
+    disabled: disabled === undefined ? isSubmitting || disabled : disabled,
   };
 };
 


### PR DESCRIPTION
When implementing auto-saving TextFields it is a problem when the field becomes disabled when submitting the form. Focus is lost on the field, interrupting the user's entry.

The existing logic allows for setting the disabled prop to true, but if set to false it always clobbers it with the value of isSubmitting. This change always respects the value of the disabled prop if set, regardless of the value.