### PR TITLE
Fixed TextFieldProps

### DIFF
--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -4,18 +4,13 @@ import MuiTextField, {
 } from '@material-ui/core/TextField';
 import { FieldProps, getIn } from 'formik';
 
-// Special omit for TextField - https://github.com/microsoft/TypeScript/issues/28791
-export type AllKeys<T> = T extends T ? keyof T : never;
-export type Omit<T, K extends AllKeys<T>> = T extends T
-  ? Pick<T, Exclude<keyof T, K>>
-  : never;
-
 export type TextFieldProps = FieldProps &
   Omit<MuiTextFieldProps, 'error' | 'name' | 'onChange' | 'value'>;
 
 export const fieldToTextField = ({
   field,
   form,
+  variant = 'standard',
   disabled = false,
   ...props
 }: TextFieldProps): MuiTextFieldProps => {
@@ -28,6 +23,7 @@ export const fieldToTextField = ({
   return {
     ...props,
     ...field,
+    variant,
     error: showError,
     helperText: showError ? fieldError : props.helperText,
     disabled: isSubmitting || disabled,

--- a/src/__tests__/TextField.test.tsx
+++ b/src/__tests__/TextField.test.tsx
@@ -18,7 +18,7 @@ test('TextField Renders Correctly', () => {
 
 test('Wrapped TextField', () => {
   const TextFieldComponent = (p: TextFieldProps) => (
-    <TextField variant="outlined" {...p} />
+    <TextField variant="standard" {...p} />
   );
 
   const component = renderer.create(

--- a/src/__tests__/TextField.test.tsx
+++ b/src/__tests__/TextField.test.tsx
@@ -2,13 +2,29 @@ import * as React from 'react';
 import { Formik, Field, Form } from 'formik';
 import renderer from 'react-test-renderer';
 
-import { TextField } from '../TextField';
+import { TextField, TextFieldProps } from '../TextField';
 
 test('TextField Renders Correctly', () => {
   const component = renderer.create(
     <Formik initialValues={{}} onSubmit={() => null}>
       <Form>
         <Field name="test" label="Text" component={TextField} />
+      </Form>
+    </Formik>
+  );
+
+  expect(component.toJSON()).toMatchSnapshot();
+});
+
+test('Wrapped TextField', () => {
+  const TextFieldComponent = (p: TextFieldProps) => (
+    <TextField variant="outlined" {...p} />
+  );
+
+  const component = renderer.create(
+    <Formik initialValues={{}} onSubmit={() => null}>
+      <Form>
+        <Field name="test" label="Text" component={TextFieldComponent} />
       </Form>
     </Formik>
   );

--- a/src/__tests__/__snapshots__/TextField.test.tsx.snap
+++ b/src/__tests__/__snapshots__/TextField.test.tsx.snap
@@ -33,3 +33,37 @@ exports[`TextField Renders Correctly 1`] = `
   </div>
 </form>
 `;
+
+exports[`Wrapped TextField 1`] = `
+<form
+  onReset={[Function]}
+  onSubmit={[Function]}
+>
+  <div
+    className="MuiFormControl-root MuiTextField-root"
+  >
+    <label
+      className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated"
+      data-shrink={false}
+    >
+      Text
+    </label>
+    <div
+      className="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-formControl MuiInput-formControl"
+      onClick={[Function]}
+    >
+      <input
+        aria-invalid={false}
+        className="MuiInputBase-input MuiInput-input"
+        disabled={false}
+        name="test"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        required={false}
+        type="text"
+      />
+    </div>
+  </div>
+</form>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11844,9 +11844,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
-  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
+  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
https://github.com/stackworx/formik-material-ui/pull/82

```
 FAIL  src/__tests__/TextField.test.tsx
  ● Test suite failed to run

    TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):
    src/__tests__/TextField.test.tsx:21:6 - error TS2322: Type '{ field: { onChange: { (e: ChangeEvent<any>): void; <T = unknown>(field: T): T extends ChangeEvent<any> ? void : (e: unknown) => void; }; onBlur: { (e: FocusEvent<any>): void; <T = any>(fieldOrEvent: T): T extends string ? (e: any) => void : void; }; value: any; name: string; }; ... 276 more ...; ty
pe?: string | und...' is not assignable to type '(IntrinsicAttributes & FieldProps<any> & Pick<StandardTextFieldProps, "label" | "select" | "style" | "title" | "ref" | "className" | "classes" | "innerRef" | "key" | "defaultChecked" | ... 265 more ... | "type"> & { ...; }) | (IntrinsicAttributes & ... 2 more ... & { ...; }) | (IntrinsicAttributes & ... 2 more ...
 &...'.
      Type '{ field: { onChange: { (e: ChangeEvent<any>): void; <T = unknown>(field: T): T extends ChangeEvent<any> ? void : (e: unknown) => void; }; onBlur: { (e: FocusEvent<any>): void; <T = any>(fieldOrEvent: T): T extends string ? (e: any) => void : void; }; value: any; name: string; }; ... 276 more ...; type?: string | und...' is not assignable to type '(In
trinsicAttributes & FieldProps<any> & Pick<StandardTextFieldProps, "label" | "select" | "style" | "title" | "ref" | "className" | "classes" | "innerRef" | "key" | "defaultChecked" | ... 265 more ... | "type"> & { ...; }) | (IntrinsicAttributes & ... 2 more ... & { ...; }) | (IntrinsicAttributes & ... 2 more ... &...'.
        Type '{ field: { onChange: { (e: ChangeEvent<any>): void; <T = unknown>(field: T): T extends ChangeEvent<any> ? void : (e: unknown) => void; }; onBlur: { (e: FocusEvent<any>): void; <T = any>(fieldOrEvent: T): T extends string ? (e: any) => void : void; }; value: any; name: string; }; ... 276 more ...; type?: string | und...' is not assignable to type 'P
ick<OutlinedTextFieldProps, "label" | "select" | "style" | "title" | "ref" | "className" | "classes" | "innerRef" | "key" | "defaultChecked" | "defaultValue" | "suppressContentEditableWarning" | ... 263 more ... | "type">'.
          Types of property 'variant' are incompatible.
            Type '"standard" | "outlined"' is not assignable to type '"outlined"'.
              Type '"standard"' is not assignable to type '"outlined"'.

    21     <TextField variant="outlined" {...p} />
```