### PR TITLE
Remove the default variant style, fix type issue

### DIFF
--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -5,12 +5,15 @@ import MuiTextField, {
 import { FieldProps, getIn } from 'formik';
 
 export type TextFieldProps = FieldProps &
-  Omit<MuiTextFieldProps, 'error' | 'name' | 'onChange' | 'value'>;
+  Omit<MuiTextFieldProps, 'error' | 'name' | 'onChange' | 'value'> & {
+    // Fix for the type for variant which is using union
+    // https://stackoverflow.com/questions/55664421
+    variant: 'standard' | 'filled' | 'outlined' | undefined;
+  };
 
 export const fieldToTextField = ({
   field,
   form,
-  variant = 'standard',
   disabled,
   ...props
 }: TextFieldProps): MuiTextFieldProps => {
@@ -23,7 +26,6 @@ export const fieldToTextField = ({
   return {
     ...props,
     ...field,
-    variant,
     error: showError,
     helperText: showError ? fieldError : props.helperText,
     disabled: disabled != undefined ? disabled : isSubmitting,


### PR DESCRIPTION
Fixes #87 which was caused by #85 

There were typing issues with the TextField as it was extending the Mui `TextFieldProps` type, which caused a problem with the `varient` type, which is a Union of several types.

To fix this, I hard coded it. This may not be the right way, so I'm happy to take feedback.

But in the end, this removes the hard-coded variant of `standard`