### PR TITLE
Cast checkbox checked prop to a boolean to avoid console.warn output.

### DIFF
--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -22,7 +22,7 @@ export const fieldToCheckbox = ({
     ...props,
     ...field,
     // TODO handle indeterminate
-    checked: field.value,
+    checked: !!field.value,
     value: field.value ? 'checked' : '',
   };
 };

--- a/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`Checkbox Renders Correctly 1`] = `
         />
       </svg>
       <input
+        checked={false}
         className="PrivateSwitchBase-input-10"
         data-indeterminate={false}
         disabled={false}


### PR DESCRIPTION
Removes the ```Warning: Failed prop type: Invalid prop `checked` of type `string` supplied to `ForwardRef(Checkbox)`, expected `boolean`.``` warning that is flooding the console.