### PR TITLE
Add MIT license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "formik-material-ui",
   "version": "0.0.22",
+  "license": "MIT",
   "typings": "dist/main.d.ts",
   "peerDependencies": {
     "@material-ui/core": ">=4.0.0",


### PR DESCRIPTION
License unchanged, simply add to package metadata.

This allows [license-checker (GitHub)](https://github.com/davglass/license-checker) to properly read the license in this repo, instead of returning `"UNKNOWN"`. I tested that this fixes that issue in my node_modules directory.