### PR TITLE
Formik 2.0: Include value as an important prop in Checkbox

### DIFF
--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -8,7 +8,7 @@ export interface CheckboxProps
   extends FieldProps,
     Omit<
       MuiCheckboxProps,
-      'form' | 'checked' | 'defaultChecked' | 'name' | 'onChange' | 'value'
+      'form' | 'checked' | 'defaultChecked' | 'name' | 'onChange'
     > {}
 
 export const fieldToCheckbox = ({
@@ -23,7 +23,7 @@ export const fieldToCheckbox = ({
     ...field,
     // TODO handle indeterminate
     checked: field.value,
-    value: field.value ? 'checked' : '',
+    value: field.value ? 'checked' : props.value,
   };
 };
 


### PR DESCRIPTION
I don't think this pull request is fully complete, but I believe that the below is should at least be included for making this library compatible with Formik 2.0.

In the [migration guide](https://jaredpalmer.com/formik/docs/migrating-v2#checkboxes-and-select-multiple) they outline that `value` is now an important prop and follows roughly how it is used in HTML checkboxes.

If we currently use this library's Checkbox with Formik 2.0 it breaks with this warning:
```
Failed prop type: Invalid prop `checked` of type `array` supplied to `ForwardRef(Checkbox)`, expected `boolean`.
```
because `field.value` comes back with an array when a `value` prop is given. Normally the value would be something like `['designer']` as in the migration guide, but it should be omitted when it's only a simple boolean field with no `value` prop. But here it comes back as `[""]` when it instead should return a boolean. This is because of [line 26 in Checkbox.tsx](https://github.com/stackworx/formik-material-ui/blob/master/src/Checkbox.tsx#L26).

Apologies I can't finish off the pull request right now, but I thought I'd write up my discoveries for everyone at the least.