### PR TITLE
Refactor: Use nullish coalescing operator to simplify undefined checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "husky": "^1.2.0",
     "jest": "^23.4.2",
     "lerna": "^3.5.1",
-    "prettier": "^1.15.3",
+    "prettier": "^1.19.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-test-renderer": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "ts-jest": "^23.10.5",
     "ts-loader": "^5.3.1",
     "tslib": "^1.9.3",
-    "typescript": "^3.5.1",
+    "typescript": "^3.7.4",
     "yup": "^0.26.0"
   },
   "files": [

--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -18,7 +18,7 @@ export const fieldToCheckbox = ({
   ...props
 }: CheckboxProps): MuiCheckboxProps => {
   return {
-    disabled: disabled != undefined ? disabled : isSubmitting,
+    disabled: disabled ?? isSubmitting,
     ...props,
     ...field,
     // TODO handle indeterminate

--- a/src/InputBase.tsx
+++ b/src/InputBase.tsx
@@ -15,7 +15,7 @@ export const fieldToInputBase = ({
   ...props
 }: InputBaseProps): MuiInputBaseProps => {
   return {
-    disabled: disabled != undefined ? disabled : isSubmitting,
+    disabled: disabled ?? isSubmitting,
     ...props,
     ...field,
   };

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -35,7 +35,7 @@ export const fieldToSelect = ({
   );
 
   return {
-    disabled: disabled != undefined ? disabled : isSubmitting,
+    disabled: disabled ?? isSubmitting,
     ...props,
     ...field,
     onChange,

--- a/src/Switch.tsx
+++ b/src/Switch.tsx
@@ -18,7 +18,7 @@ export const fieldToSwitch = ({
   ...props
 }: SwitchProps): MuiSwitchProps => {
   return {
-    disabled: disabled != undefined ? disabled : isSubmitting,
+    disabled: disabled ?? isSubmitting,
     ...props,
     ...field,
     value: field.name,

--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -28,7 +28,7 @@ export const fieldToTextField = ({
     ...field,
     error: showError,
     helperText: showError ? fieldError : props.helperText,
-    disabled: disabled != undefined ? disabled : isSubmitting,
+    disabled: disabled ?? isSubmitting,
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9629,10 +9629,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.15.3:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-error@^2.1.1:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11821,10 +11821,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.5.1:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@^3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
Typescript supports [nullish coalescing operator ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) in version [3.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing
)


I thought it's a good idea to replace  comparison between value and undefined with this feature.

From
```typescript
{
   disabled: disabled != undefined ? disabled : isSubmitting,
}
```

to
```typescript
{
    disabled: disabled ?? isSubmitting,
};
```



would complile to:

```javascript
{
    disabled: (disabled !== null && disabled !== void 0 ? disabled : isSubmitting),
};
```



I also upgraded prettier to support this syntax feature.

Ref:
https://github.com/prettier/prettier/issues/6595