### PR TITLE
Don't force standard variant on TextField

### DIFF
--- a/packages/formik-material-ui/src/TextField.tsx
+++ b/packages/formik-material-ui/src/TextField.tsx
@@ -37,7 +37,7 @@ export function useFieldToTextField<Val = unknown>(
     error: showError,
     helperText: showError ? fieldError : props.helperText,
     disabled: disabled ?? isSubmitting,
-    variant: props.variant ?? 'standard',
+    variant: props.variant,
     ...customize?.(fieldProps),
   };
 }


### PR DESCRIPTION
Material-UI allows customizing default props for components in the theme. This library is currently overriding the theme-provided variant prop by defaulting to `'standard'` internally.