### PR TITLE
Be able to touch on change

### DIFF
--- a/packages/formik-material-ui/src/TextField.tsx
+++ b/packages/formik-material-ui/src/TextField.tsx
@@ -22,7 +22,7 @@ export function fieldToTextField({
     ...props,
     ...field,
     onChange(e) {
-      if (touchOnChange) {
+      if (touchOnChange && !touched) {
         setTouched({ [field.name]: true });
       }
       const onChange = props.onChange || field.onChange;

--- a/packages/formik-material-ui/src/TextField.tsx
+++ b/packages/formik-material-ui/src/TextField.tsx
@@ -22,7 +22,7 @@ export function fieldToTextField({
     ...props,
     ...field,
     onChange(e) {
-      if (touchOnChange && !touched) {
+      if (touchOnChange && !getIn(touched, field.name)) {
         setTouched({ [field.name]: true });
       }
       const onChange = props.onChange || field.onChange;

--- a/packages/formik-material-ui/src/TextField.tsx
+++ b/packages/formik-material-ui/src/TextField.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react';
-import MuiTextField, {
-  TextFieldProps as MuiTextFieldProps,
-} from '@material-ui/core/TextField';
+import MuiTextField, { TextFieldProps as MuiTextFieldProps } from '@material-ui/core/TextField';
 import { FieldProps, getIn } from 'formik';
 
 export interface TextFieldProps
   extends FieldProps,
-    Omit<MuiTextFieldProps, 'name' | 'value' | 'error'> {}
+    Omit<MuiTextFieldProps, 'name' | 'value' | 'error'> {
+  touchOnChange?: boolean
+}
 
 export function fieldToTextField({
   disabled,
   field,
-  form: { isSubmitting, touched, errors },
+  form: { isSubmitting, touched, errors, setTouched },
+  touchOnChange,
   ...props
 }: TextFieldProps): MuiTextFieldProps {
   const fieldError = getIn(errors, field.name);
@@ -20,6 +21,13 @@ export function fieldToTextField({
   return {
     ...props,
     ...field,
+    onChange(e) {
+      if (touchOnChange) {
+        setTouched({ [field.name]: true });
+      }
+      const onChange = props.onChange || field.onChange;
+      onChange && onChange(e);
+    },
     error: showError,
     helperText: showError ? fieldError : props.helperText,
     disabled: disabled ?? isSubmitting,


### PR DESCRIPTION
### Note

One of the features missing from Formik is being able to show errors when the user is typing, instead of waiting for the **first** blur.

I was going to try some PR on Formik instead of here, but @jaredpalmer already gave his position about this issue: https://github.com/jaredpalmer/formik/issues/237
And he wants you to do it by yourself using the render function. Because of that, `formik-material-ui` would become pointless for me, but instead, I decided to fix this problem here so I can keep using it.

This PR I made is just a suggestion. I will keep this version for myself, but if you guys approve of this feature, I'll gladly make the documentation part.

### Explanation

I added a new property that can be used on the Field that will make the field touched when the field value gets changed.