### PR TITLE
:tada: (validations): add status support for handling errors

### DIFF
--- a/docs/docs/guide/faq.md
+++ b/docs/docs/guide/faq.md
@@ -90,3 +90,11 @@ A common scenario where this is problematic is where using Formik for search. He
   )}
 </Formik>
 ```
+
+## Can i use setStatus for managing async errors?
+
+Yes, you can store your async errors inside status.errors in the same way formik errors work. Errors are reported like:
+
+`{ [key: string]: string }`
+
+https://github.com/jaredpalmer/formik/issues/150

--- a/packages/formik-material-ui-pickers/src/DatePicker.tsx
+++ b/packages/formik-material-ui-pickers/src/DatePicker.tsx
@@ -11,11 +11,12 @@ export interface DatePickerProps
 
 export function fieldToDatePicker({
   field,
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
+  form: { isSubmitting, touched, errors, status = {}, setFieldValue, setFieldError },
   disabled,
   ...props
 }: DatePickerProps): MuiDatePickerProps {
-  const fieldError = getIn(errors, field.name);
+  const fieldError =
+    getIn(errors, field.name) || getIn(status.errors, field.name);;
   const showError = getIn(touched, field.name) && !!fieldError;
 
   return {

--- a/packages/formik-material-ui-pickers/src/DateTimePicker.tsx
+++ b/packages/formik-material-ui-pickers/src/DateTimePicker.tsx
@@ -12,10 +12,11 @@ export interface DateTimePickerProps
 export function fieldToDateTimePicker({
   disabled,
   field,
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
+  form: { isSubmitting, touched, errors, status = {}, setFieldValue, setFieldError },
   ...props
 }: DateTimePickerProps): MuiDateTimePickerProps {
-  const fieldError = getIn(errors, field.name);
+  const fieldError =
+    getIn(errors, field.name) || getIn(status.errors, field.name);;
   const showError = getIn(touched, field.name) && !!fieldError;
 
   return {

--- a/packages/formik-material-ui-pickers/src/KeyboardDatePicker.tsx
+++ b/packages/formik-material-ui-pickers/src/KeyboardDatePicker.tsx
@@ -12,10 +12,11 @@ export interface KeyboardDatePickerProps
 export function fieldToKeyboardDatePicker({
   disabled,
   field,
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
+  form: { isSubmitting, touched, errors, status = {}, setFieldValue, setFieldError },
   ...props
 }: KeyboardDatePickerProps): MuiKeyboardDatePickerProps {
-  const fieldError = getIn(errors, field.name);
+  const fieldError =
+    getIn(errors, field.name) || getIn(status.errors, field.name);
   const showError = getIn(touched, field.name) && !!fieldError;
 
   return {

--- a/packages/formik-material-ui-pickers/src/KeyboardDateTimePicker.tsx
+++ b/packages/formik-material-ui-pickers/src/KeyboardDateTimePicker.tsx
@@ -15,10 +15,11 @@ export interface KeyboardDateTimePickerProps
 export function fieldToKeyboardDateTimePicker({
   disabled,
   field,
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
+  form: { isSubmitting, touched, errors, status = {}, setFieldValue, setFieldError },
   ...props
 }: KeyboardDateTimePickerProps): MuiKeyboardDateTimePickerProps {
-  const fieldError = getIn(errors, field.name);
+  const fieldError =
+    getIn(errors, field.name) || getIn(status.errors, field.name);
   const showError = getIn(touched, field.name) && !!fieldError;
 
   return {

--- a/packages/formik-material-ui-pickers/src/KeyboardTimePicker.tsx
+++ b/packages/formik-material-ui-pickers/src/KeyboardTimePicker.tsx
@@ -12,10 +12,18 @@ export interface KeyboardTimePickerProps
 export function fieldToKeyboardTimePicker({
   disabled,
   field,
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
+  form: {
+    isSubmitting,
+    touched,
+    errors,
+    status = {},
+    setFieldValue,
+    setFieldError,
+  },
   ...props
 }: KeyboardTimePickerProps): MuiKeyboardTimePickerProps {
-  const fieldError = getIn(errors, field.name);
+  const fieldError =
+    getIn(errors, field.name) || getIn(status.errors, field.name);
   const showError = getIn(touched, field.name) && !!fieldError;
 
   return {

--- a/packages/formik-material-ui-pickers/src/TimePicker.tsx
+++ b/packages/formik-material-ui-pickers/src/TimePicker.tsx
@@ -12,10 +12,18 @@ export interface TimePickerProps
 export function fieldToTimePicker({
   disabled,
   field,
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
+  form: {
+    isSubmitting,
+    touched,
+    errors,
+    status = {},
+    setFieldValue,
+    setFieldError,
+  },
   ...props
 }: TimePickerProps): MuiTimePickerProps {
-  const fieldError = getIn(errors, field.name);
+  const fieldError =
+    getIn(errors, field.name) || getIn(status.errors, field.name);
   const showError = getIn(touched, field.name) && !!fieldError;
 
   return {

--- a/packages/formik-material-ui/src/SimpleFileUpload.tsx
+++ b/packages/formik-material-ui/src/SimpleFileUpload.tsx
@@ -14,13 +14,15 @@ export interface SimpleFileUploadProps extends FieldProps {
 
 export const SimpleFileUpload = ({
   field,
-  form: { isSubmitting, touched, errors, setFieldValue },
+  form: { isSubmitting, touched, errors, setFieldValue, status = {} },
   label,
   disabled = false,
   InputProps: inputProps,
   InputLabelProps: inputLabelProps,
 }: SimpleFileUploadProps) => {
-  const error = getIn(touched, field.name) && getIn(errors, field.name);
+  const error =
+    getIn(touched, field.name) &&
+    (getIn(errors, field.name) || getIn(status.errors, field.name));
 
   return (
     <div>

--- a/packages/formik-material-ui/src/TextField.tsx
+++ b/packages/formik-material-ui/src/TextField.tsx
@@ -11,10 +11,11 @@ export interface TextFieldProps
 export function fieldToTextField({
   disabled,
   field,
-  form: { isSubmitting, touched, errors },
+  form: { isSubmitting, touched, errors, status = {} },
   ...props
 }: TextFieldProps): MuiTextFieldProps {
-  const fieldError = getIn(errors, field.name);
+  const fieldError =
+    getIn(errors, field.name) || getIn(status.errors, field.name);
   const showError = getIn(touched, field.name) && !!fieldError;
 
   return {


### PR DESCRIPTION
## What is the focus of this PR?

Due to https://github.com/jaredpalmer/formik/issues/150 many people use formik `status` for managing async errors.

This PR includes `status` prop to be used as well as `errors` when displaying field errors.

## Possible improvements?
I made it work for having the errors inside status.errors. This is completely arbitrary and might not be done this way. I chose to do it this way because when you are managing async errors you might probably want to set an isLoading as well.