### PR TITLE
Fix picker validation

### DIFF
--- a/packages/formik-material-ui-pickers/src/DatePicker.tsx
+++ b/packages/formik-material-ui-pickers/src/DatePicker.tsx
@@ -4,6 +4,7 @@ import {
   DatePickerProps as MuiDatePickerProps,
 } from '@material-ui/pickers';
 import { FieldProps, getIn } from 'formik';
+import { createErrorHandler } from './errorHandler';
 
 export interface DatePickerProps
   extends FieldProps,
@@ -27,13 +28,7 @@ export function fieldToDatePicker({
     onChange(date) {
       setFieldValue(field.name, date);
     },
-    onError(error) {
-      if (error !== fieldError && !(error == '' && !fieldError)) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore - https://github.com/jaredpalmer/formik/pull/2286
-        setFieldError(field.name, error ? String(error) : undefined);
-      }
-    },
+    onError: createErrorHandler(fieldError, field.name, setFieldError)
   };
 }
 

--- a/packages/formik-material-ui-pickers/src/DateTimePicker.tsx
+++ b/packages/formik-material-ui-pickers/src/DateTimePicker.tsx
@@ -4,6 +4,7 @@ import {
   DateTimePickerProps as MuiDateTimePickerProps,
 } from '@material-ui/pickers';
 import { FieldProps, getIn } from 'formik';
+import { createErrorHandler } from './errorHandler';
 
 export interface DateTimePickerProps
   extends FieldProps,
@@ -27,13 +28,7 @@ export function fieldToDateTimePicker({
     onChange(date) {
       setFieldValue(field.name, date);
     },
-    onError(error) {
-      if (error !== fieldError && !(error == '' && !fieldError)) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore - https://github.com/jaredpalmer/formik/pull/2286
-        setFieldError(field.name, error ? String(error) : undefined);
-      }
-    },
+    onError: createErrorHandler(fieldError, field.name, setFieldError)
   };
 }
 

--- a/packages/formik-material-ui-pickers/src/KeyboardDatePicker.tsx
+++ b/packages/formik-material-ui-pickers/src/KeyboardDatePicker.tsx
@@ -4,6 +4,7 @@ import {
   KeyboardDatePickerProps as MuiKeyboardDatePickerProps,
 } from '@material-ui/pickers';
 import { FieldProps, getIn } from 'formik';
+import { createErrorHandler } from './errorHandler';
 
 export interface KeyboardDatePickerProps
   extends FieldProps,
@@ -27,13 +28,7 @@ export function fieldToKeyboardDatePicker({
     onChange(date) {
       setFieldValue(field.name, date);
     },
-    onError(error) {
-      if (error !== fieldError && !(error == '' && !fieldError)) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore - https://github.com/jaredpalmer/formik/pull/2286
-        setFieldError(field.name, error ? String(error) : undefined);
-      }
-    },
+    onError: createErrorHandler(fieldError, field.name, setFieldError)
   };
 }
 

--- a/packages/formik-material-ui-pickers/src/KeyboardDateTimePicker.tsx
+++ b/packages/formik-material-ui-pickers/src/KeyboardDateTimePicker.tsx
@@ -4,6 +4,7 @@ import {
   KeyboardDateTimePickerProps as MuiKeyboardDateTimePickerProps,
 } from '@material-ui/pickers';
 import { FieldProps, getIn } from 'formik';
+import { createErrorHandler } from './errorHandler';
 
 export interface KeyboardDateTimePickerProps
   extends FieldProps,
@@ -30,13 +31,7 @@ export function fieldToKeyboardDateTimePicker({
     onChange(date) {
       setFieldValue(field.name, date);
     },
-    onError(error) {
-      if (error !== fieldError && !(error == '' && !fieldError)) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore - https://github.com/jaredpalmer/formik/pull/2286
-        setFieldError(field.name, error ? String(error) : undefined);
-      }
-    },
+    onError: createErrorHandler(fieldError, field.name, setFieldError)
   };
 }
 

--- a/packages/formik-material-ui-pickers/src/KeyboardTimePicker.tsx
+++ b/packages/formik-material-ui-pickers/src/KeyboardTimePicker.tsx
@@ -4,6 +4,7 @@ import {
   KeyboardTimePickerProps as MuiKeyboardTimePickerProps,
 } from '@material-ui/pickers';
 import { FieldProps, getIn } from 'formik';
+import { createErrorHandler } from './errorHandler';
 
 export interface KeyboardTimePickerProps
   extends FieldProps,
@@ -27,13 +28,7 @@ export function fieldToKeyboardTimePicker({
     onChange(date) {
       setFieldValue(field.name, date);
     },
-    onError(error) {
-      if (error !== fieldError && !(error == '' && !fieldError)) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore - https://github.com/jaredpalmer/formik/pull/2286
-        setFieldError(field.name, error ? String(error) : undefined);
-      }
-    },
+    onError: createErrorHandler(fieldError, field.name, setFieldError)
   };
 }
 

--- a/packages/formik-material-ui-pickers/src/errorHandler.ts
+++ b/packages/formik-material-ui-pickers/src/errorHandler.ts
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+
+export function createErrorHandler(fieldError: unknown, fieldName: string, setFieldError: (field: string, message: string) => void) {
+  return (error : ReactNode) => {
+    if (error !== fieldError && error !== '') {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+      // @ts-ignore - https://github.com/jaredpalmer/formik/pull/2286
+      setFieldError(fieldName, error ? String(error) : undefined);
+    }
+  }
+}


### PR DESCRIPTION
Modified the condition to run the `onError` handler within pickers so they don't remove validation errors coming from fields.
Extracted the error handler to a separate function to reduce repetition.