### PR TITLE
doc: add type="checkbox" prop to component examples

### DIFF
--- a/docs/docs/api/material-ui.md
+++ b/docs/docs/api/material-ui.md
@@ -12,7 +12,7 @@ The following props are always excluded: `name, value, error`, and additional on
 ```jsx
 import { Checkbox } from 'formik-material-ui';
 
-<Field component={Checkbox} name="checked" />;
+<Field component={Checkbox} type="checkbox" name="checked" />;
 ```
 
 #### [Material-UI Documentation](https://material-ui.com/api/checkbox/)
@@ -28,6 +28,7 @@ import { CheckboxWithLabel } from 'formik-material-ui';
 
 <Field
   component={CheckboxWithLabel}
+  type="checkbox"
   name="checked"
   Label={{ label: 'Checkbox' }}
 />;

--- a/docs/docs/api/material-ui.md
+++ b/docs/docs/api/material-ui.md
@@ -143,7 +143,7 @@ interface SimpleFileUploadProps {
 ```jsx
 import { Switch } from 'formik-material-ui';
 
-<Field component={Switch} name="switch" />;
+<Field component={Switch} type="checkbox" name="switch" />;
 ```
 
 #### [Material-UI Documentation](https://material-ui.com/api/switch/)


### PR DESCRIPTION
Adds the `type` prop to the Switch example so users know that `type="checkbox"` must be applied for the control to work correctly.